### PR TITLE
Add ex-data to exception message

### DIFF
--- a/src/honeybadger/core.clj
+++ b/src/honeybadger/core.clj
@@ -43,7 +43,9 @@
   String
     (error-map [this] {:message this})
   Throwable
-    (error-map [this] {:message (.getMessage this)
+    (error-map [this] {:message (str (.getMessage this)
+                                     (when-let [info (ex-data this)]
+                                       (str " (ex-info: " (pr-str info) ")")))
                        :class (.getName (.getClass this))
                        :backtrace (format-stacktrace (.getStackTrace this))}))
 


### PR DESCRIPTION
From my understanding, it's quite common in clojure to throw a `ExceptionInfo` generated using
[`ex-info`](https://clojuredocs.org/clojure.core/ex-info). But this honeybadger lib doesn't report the additional info provided to `ex-info`.

For now, I've added the data to the exception message. I'm not sure whether that's the way to go. An alternative would be the context. I decided against the context, because it's a field belonging to the
request, but actually this is not reflected in the API. WDYT?

Sponsored by @BillFront