### PR TITLE
Include exception causes

### DIFF
--- a/test/honeybadger/core_test.clj
+++ b/test/honeybadger/core_test.clj
@@ -1,0 +1,12 @@
+(ns honeybadger.core-test
+  (:require [clojure.test :refer :all]
+            [honeybadger.core :refer :all]))
+
+(deftest ex-chain-test
+  (let [e (->> (Exception. "C")
+               (Exception. "B")
+               (Exception. "A"))
+        [a b c] (ex-chain e)]
+    (is (= e a))
+    (is (= (.getCause e) b))
+    (is (= (.. e getCause getCause) c))))


### PR DESCRIPTION
Fix #7.

HB [supports causes](http://blog.honeybadger.io/honeybadger-now-supports-causes-nested-exceptions/). See the [updated documentation](http://docs.honeybadger.io/guides/api.html#sample-payload) on including causes in the payload.

Example:

![image](https://user-images.githubusercontent.com/1624090/29583842-a54c7830-8736-11e7-910f-f2f174d0222c.png)
